### PR TITLE
reorder builder registration

### DIFF
--- a/ShoppingTogether.API/Program.cs
+++ b/ShoppingTogether.API/Program.cs
@@ -9,7 +9,6 @@ var builder = WebApplication.CreateBuilder(args);
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
-builder.Services.RegisterServices(builder.Configuration);
 
 if (builder.Environment.IsProduction())
 {
@@ -17,6 +16,8 @@ if (builder.Environment.IsProduction())
     new Uri(builder.Configuration["KeyVault:Uri"]!),
     new DefaultAzureCredential());
 }
+
+builder.Services.RegisterServices(builder.Configuration);
 
 var app = builder.Build();
 


### PR DESCRIPTION
The ordering of service registrations was causing key vault secrets loading after services were already registered. This was causing the connection string in the RegisterServices function to be empty as it was not correctly pulling from Key Vault as expected